### PR TITLE
Include header functional and algorithm

### DIFF
--- a/src/domain_info.hpp
+++ b/src/domain_info.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include<iostream>
+#include<functional>
+#include<algorithm>
 
 #ifdef PARTICLE_SIMULATOR_MPI_PARALLEL
 #include<mpi.h>


### PR DESCRIPTION
std::grater and std::sort are used on domain_info.hpp but corresponding headers are not included.
