### PR TITLE
Fix wrong macro compiler switching for OpenMP

### DIFF
--- a/src/ps_defs.hpp
+++ b/src/ps_defs.hpp
@@ -1352,12 +1352,12 @@ namespace ParticleSimulator{
     }
 
     inline F64 GetWtime(){
-#ifdef PARTICLE_SIMULATOR_MPI_PARALLEL
+#if defined(PARTICLE_SIMULATOR_MPI_PARALLEL)
 #ifdef PARTICLE_SIMULATOR_BARRIER_FOR_PROFILE
 	Comm::barrier();
 #endif //PARTICLE_SIMULATOR_BARRIER_FOR_PROFILE
         return MPI::Wtime();
-#elif PARTICLE_SIMULATOR_THREAD_PARALLEL
+#elif defined(PARTICLE_SIMULATOR_THREAD_PARALLEL)
 	return omp_get_wtime();
 #else
 	return clock() / CLOCKS_PER_SEC;
@@ -1366,9 +1366,9 @@ namespace ParticleSimulator{
 
 
     inline F64 GetWtimeNoBarrier(){
-#ifdef PARTICLE_SIMULATOR_MPI_PARALLEL
+#if defined(PARTICLE_SIMULATOR_MPI_PARALLEL)
         return MPI::Wtime();
-#elif PARTICLE_SIMULATOR_THREAD_PARALLEL
+#elif defined(PARTICLE_SIMULATOR_THREAD_PARALLEL)
 	return omp_get_wtime();
 #else
 	return clock() / CLOCKS_PER_SEC;


### PR DESCRIPTION
# elif cannot use macro directly
