### PR TITLE
add interface for internal type

### DIFF
--- a/src/particle_system.hpp
+++ b/src/particle_system.hpp
@@ -15,13 +15,19 @@ namespace ParticleSimulator{
         TimeProfile time_profile_;
         static const S32 n_smp_ave_ = 30;
         ReallocatableArray<Tptcl> ptcl_;
-	ReallocatableArray<S32> idx_remove_ptcl_; // add 2016/09/14
+        ReallocatableArray<S32>   idx_remove_ptcl_; // add 2016/09/14
         ReallocatableArray<Tptcl> ptcl_send_;
         ReallocatableArray<Tptcl> ptcl_recv_;
         S32 n_smp_ptcl_tot_;
         bool first_call_by_initialize;
         bool first_call_by_setAverageTargetNumberOfSampleParticlePerProcess;
         bool first_call_by_DomainInfo_collect_sample_particle;
+
+    public:
+        //--- internal type interface (STL container like)
+        using ptcl_type = Tptcl;
+
+    private:
         inline bool determineWhetherParticleIsInDomain(const F64vec & pos,
                                                        const F64ort & domain) {
             bool ret = true;

--- a/src/tree_for_force.hpp
+++ b/src/tree_for_force.hpp
@@ -36,6 +36,15 @@ namespace ParticleSimulator{
         F64vec center_; // new member (not used)
         //F64ort pos_root_cell_;
 
+        //--- internal type interface (STL container like)
+        using search_mode        = TSM;
+        using force_type         = Tforce;
+        using epi_type           = Tepi;
+        using epj_type           = Tepj;
+        using moment_local_type  = Tmomloc;
+        using moment_global_type = Tmomglb;
+        using spj_type           = Tspj;
+
         //private:
     public:
 
@@ -730,6 +739,10 @@ namespace ParticleSimulator{
         S32 getNeighborListOneParticleImpl(TagSearchLongScatter, const Tptcl & ptcl, Tepj * & epj);
         template<class Tptcl>
         S32 getNeighborListOneParticleImpl(TagSearchLongSymmetry, const Tptcl & ptcl, Tepj * & epj);
+
+        //------ wrapper for returning <Tepj*>
+        template <class Tptcl>
+        Tepj* getNeighborListOneParticle(const Tptcl &ptcl, S32 &n);
 
 
         F64ort getOuterBoundaryOfLocalTree(){

--- a/src/tree_for_force_impl.hpp
+++ b/src/tree_for_force_impl.hpp
@@ -4328,7 +4328,18 @@ namespace ParticleSimulator{
     getNeighborListOneParticle(const Tptcl & ptcl, Tepj * & epj){
 	return getNeighborListOneParticleImpl(typename TSM::search_type(), ptcl, epj);
     }
-    
+
+    //--- wrapper for returning <Tepj*>
+    template<class TSM, class Tforce, class Tepi, class Tepj,
+             class Tmomloc, class Tmomglb, class Tspj>
+    template<class Tptcl>
+    Tepj* TreeForForce<TSM, Tforce, Tepi, Tepj, Tmomloc, Tmomglb, Tspj>::
+    getNeighborListOneParticle(const Tptcl &ptcl, S32 &n){
+        Tepj* ptr;
+        n = getNeighborListOneParticleImpl(typename TSM::search_type(), ptcl, ptr);
+        return ptr;
+    }
+
     // 2016 02/05
     /*
     template<class TSM, class Tforce, class Tepi, class Tepj,


### PR DESCRIPTION
add accessor of internal type (STL container like) for
PS::ParticleSystem<> and PS::TreeForForce<>.

add overload for "auto* ptr =
PS::TreeForForce::getNeighborListOneParticle(ptcl, n)"